### PR TITLE
Add mobile pinch zoom functionality

### DIFF
--- a/app/layouts/components/visualizations/viz_2d.py
+++ b/app/layouts/components/visualizations/viz_2d.py
@@ -23,7 +23,9 @@ def create_2d_tab(fig2d_0):
                 figure=fig2d_0,
                 config={
                     'displayModeBar': False,
-                    'responsive': True
+                    'responsive': True,
+                    'scrollZoom': True,
+                    'doubleClick': 'reset'
                 },
                 style={
                     'height': '50vh',

--- a/app/layouts/components/visualizations/viz_3d.py
+++ b/app/layouts/components/visualizations/viz_3d.py
@@ -24,7 +24,17 @@ def create_3d_tab(fig3d_0):
                 'displayModeBar': True,
                 'displaylogo': False,
                 'modeBarButtonsToRemove': ['pan3d', 'select3d', 'lasso3d'],
-                'responsive': True
+                'responsive': True,
+                'scrollZoom': True,
+                'doubleClick': 'reset',
+                'modeBarButtonsToAdd': [],
+                'toImageButtonOptions': {
+                    'format': 'png',
+                    'filename': 'satellite_3d_view',
+                    'height': 1080,
+                    'width': 1920,
+                    'scale': 2
+                }
             },
             style={'height': 'calc(70vh - 100px)', 'minHeight': '400px'}
         ),


### PR DESCRIPTION
Add mobile pinch zoom functionality:

- Enable mobile pinch/scroll zoom (scrollZoom: True) and doubleClick reset for 2D/3D.
- Add high-res PNG export for 3D (1920×1080, scale 2, filename satellite_3d_view).
- No breaking changes.